### PR TITLE
I'll cache you outside

### DIFF
--- a/quart_discord/client.py
+++ b/quart_discord/client.py
@@ -213,9 +213,14 @@ class DiscordOAuth2Session(_http.DiscordOAuth2HttpClient):
         return await models.UserConnection.fetch_from_api()
 
     @staticmethod
-    async def fetch_guilds() -> list:
+    async def fetch_guilds(use_cache=True) -> list:
         """This method returns list of guild objects from internal cache if it exists otherwise makes an API
         call to do so.
+
+        Parameters
+        ----------
+        use_cache : bool, optional
+            can be set to False to avoid using the cache.  
 
         Returns
         -------
@@ -223,11 +228,12 @@ class DiscordOAuth2Session(_http.DiscordOAuth2HttpClient):
             List of :py:class:`quart_discord.models.Guild` objects.
 
         """
-        user = models.User.get_from_cache()
-        try:
-            if user.guilds is not None:
-                return user.guilds
-        except AttributeError:
-            pass
+        if use_cache:
+            user = models.User.get_from_cache()
+            try:
+                if user.guilds is not None:
+                    return user.guilds
+            except AttributeError:
+                pass
 
         return await models.Guild.fetch_from_api()


### PR DESCRIPTION
Don't make me use the cache when requesting a User's guilds.  Because otherwise I would have to refresh the entire OAuth session if say I was depending on my role within certain guilds which could be changing within the scope of an OAuth session.... (say administrator if a bot relied on knowing which guilds you were administrator of)