### PR TITLE
Fix MismatchingStateError when state is a bytes object

### DIFF
--- a/quart_discord/client.py
+++ b/quart_discord/client.py
@@ -55,7 +55,10 @@ class DiscordOAuth2Session(_http.DiscordOAuth2HttpClient):
 
     @staticmethod
     def __get_state():
-        return session.get("DISCORD_OAUTH2_STATE", str())
+        _state = session.get("DISCORD_OAUTH2_STATE", str())
+        if isinstance(_state, bytes):
+            _state = _state.decode()
+        return _state
 
     async def create_session(
             self, scope: list = None, *, data: dict = None, prompt: bool = True,


### PR DESCRIPTION
Full credit goes to [williamhatcher](https://github.com/williamhatcher), who found a quick fix to this issue for Flask-Discord (see this [PR](https://github.com/thec0sm0s/Flask-Discord/pull/37)).