### PR TITLE
Fix "Some cookies incorrectly use the recommended SameSite attribute on Firefox"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ app = Quart(__name__)
 
 app.secret_key = b"random bytes representing quart secret key"
 
+app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
 app.config["DISCORD_CLIENT_ID"] = 490732332240863233    # Discord client ID.
 app.config["DISCORD_CLIENT_SECRET"] = ""                # Discord client secret.
 app.config["DISCORD_REDIRECT_URI"] = ""                 # URL to your callback endpoint.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,6 +9,7 @@ app = Quart(__name__)
 app.secret_key = b"%\xe0'\x01\xdeH\x8e\x85m|\xb3\xffCN\xc9g"
 os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "true"    # !! Only in development environment.
 
+app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
 app.config["DISCORD_CLIENT_ID"] = 490732332240863233
 app.config["DISCORD_CLIENT_SECRET"] = os.getenv("DISCORD_CLIENT_SECRET")
 app.config["DISCORD_BOT_TOKEN"] = os.getenv("DISCORD_BOT_TOKEN")


### PR DESCRIPTION
Hello, I made this pull request to fix the warning of firefox saying that the session cookie has no SameSite parameters defined, which can cause strange behavior of cookies.